### PR TITLE
【Fixed】デバッグツールを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   # gem 'web-console', '~> 2.0'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  # dive22用
   gem 'spring'
   gem 'pry-rails'
   gem 'better_errors'
@@ -60,6 +61,7 @@ group :development do
   gem 'letter_opener_web'
   gem 'web-console', '~> 2.0'
   # gem 'dotenv-rails'
+  gem 'binding_of_caller'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)


### PR DESCRIPTION
#2 

gemfileにdevelopmentに下記を追記し、bundle installを行った
- gem 'pry-rails'
- gem 'better_errors'
- gem 'binding_of_caller' 

better_errorsは初期設定として、
config/environments/development.rbに以下を追記。
BetterErrors::Middleware.allow_ip! "0.0.0.0/0"

0.0.0.0/0の指定により、全てのipアドレスを許可